### PR TITLE
Ops 5147

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,11 +7,10 @@ Ansible role to install filebeat with a simple configuration.
 Role Variables
 --------------
 
-- version: filebeat version. (by default 6.5.4)
-- log_tags: List of tags to be added to the logs (by default [])
+- version: filebeat version. (by default 7.5.0).
+- pipelinematch: List of tags and list of paths to be parsed by filebeat. Wildcard is allowed.
 - elastic_hosts: List of elasticsearch ingress URLs.
 - bulk_max_size: Max number of logs to be sent at the same time. (by default 50)
-- paths: List of all the log paths to be sent. Wildcard is allowed.
 
 Dependencies
 ------------
@@ -23,10 +22,13 @@ Example Playbook
 
     - hosts: servers
       roles:
-         -
-           role: devops_cmp.ansible_filebeat
-           version: 6.5.4
-           log_tags: ['prod', 'myapp', 'mycomponent']
+         - role: devops_cmp.ansible_filebeat
+           version: 7.5.0
+           pipelinematch:
+             tags:
+             - ["httpd","httpd-error"]
+             paths:
+             - ["/var/log/httpd","/var/log/httpd/*error*"]
+
            elastic_hosts: ['https://ingest.mycluster.com:443']
-           bulk_max_size: 200
-           paths: ['/my/path/tologs/*']
+           bulk_max_size: 50

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ Example Playbook
            version: 7.5.0
            processors:
              - paths: ['/var/log/httpd/*access.log']
-               tags: ['httpd', 'access', 'isprime', '2.2']
+               tags: ['httpd', 'access', '2.2']
                type: 'log'
 
              - paths: ['/var/log/httpd/*error.log', 'error_log']

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Role Variables
 --------------
 
 - version: filebeat version. (by default 7.5.0).
-- pipelinematch: List of tags and list of paths to be parsed by filebeat. Wildcard is allowed.
+- processors: configuration of log handling . Path , tags and input type.
 - elastic_hosts: List of elasticsearch ingress URLs.
 - bulk_max_size: Max number of logs to be sent at the same time. (by default 50)
 
@@ -24,11 +24,18 @@ Example Playbook
       roles:
          - role: devops_cmp.ansible_filebeat
            version: 7.5.0
-           pipelinematch:
-             tags:
-             - ["httpd","httpd-error"]
-             paths:
-             - ["/var/log/httpd","/var/log/httpd/*error*"]
+           processors:
+             - paths: ['/var/log/httpd/*access.log']
+               tags: ['httpd', 'access', 'isprime', '2.2']
+               type: 'log'
+
+             - paths: ['/var/log/httpd/*error.log', 'error_log']
+               tags: ['httpd', 'error', '2.2']
+               type: 'log'
+
+             - host: 'localhost:5514'
+               tags: ['httpd', 'error', '2.2']
+               type: 'udp'
 
            elastic_hosts: ['https://ingest.mycluster.com:443']
            bulk_max_size: 50

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -2,6 +2,5 @@
 # defaults file for ansible_filebeat
 version: 6.5.4
 bulk_max_size : 50
-log_tags: []
 elastic_hosts: []
-paths: []
+pipelinematch: []

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -3,4 +3,4 @@
 version: 7.5.0
 bulk_max_size : 50
 elastic_hosts: []
-pipelinematch: []
+processors: []

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,6 +1,6 @@
 ---
 # defaults file for ansible_filebeat
-version: 6.5.4
+version: 7.5.0
 bulk_max_size : 50
 elastic_hosts: []
 pipelinematch: []

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,5 +1,16 @@
 ---
 # tasks file for ansible_filebeat
+
+- name: get the rpm package facts
+  package_facts:
+    manager: "auto"
+
+- name: uninstall old filebeat package
+  yum:
+    name: filebeat
+    state: absent
+  when: "ansible_facts.packages.filebeat[0].version != version"
+
 - name: Install filebeat from elastic url
   yum:
     name: "https://artifacts.elastic.co/downloads/beats/filebeat/filebeat-{{ version }}-x86_64.rpm"
@@ -11,7 +22,14 @@
     dest: "/etc/filebeat/filebeat.yml"
     mode: 0644
 
-- name: Filebeat service enabled
+- name: Filebeat service enabled - systemd lovers
   systemd:
     name: filebeat
     enabled: yes
+  when: ansible_distribution == "CentOS" and ansible_distribution_major_version > '6'
+
+- name: Filebeat service enabled - initid lovers
+  service:
+    name: filebeat
+    enabled: yes
+  when: ansible_distribution == "CentOS" and ansible_distribution_major_version < '7'

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -15,23 +15,23 @@
   yum:
     name: "https://artifacts.elastic.co/downloads/beats/filebeat/filebeat-{{ version }}-x86_64.rpm"
     state: present
+  when: "ansible_facts.packages.filebeat[0].version != version"
 
 - name: Filebeat configuration
   template:
     src: templates/filebeat.yml.jinja
     dest: "/etc/filebeat/filebeat.yml"
     mode: 0644
+  when: "ansible_facts.packages.filebeat[0].version != version"
 
 - name: Filebeat service enabled - systemd lovers
   systemd:
     name: filebeat
     enabled: yes
-    state: restarted
-  when: ansible_distribution == "CentOS" and ansible_distribution_major_version > '6'
+  when: ansible_distribution == "CentOS" and ansible_distribution_major_version > '6' and "ansible_facts.packages.filebeat[0].version != version"
 
 - name: Filebeat service enabled - initid lovers
   service:
     name: filebeat
     enabled: yes
-    state: restarted
-  when: ansible_distribution == "CentOS" and ansible_distribution_major_version < '7'
+  when: ansible_distribution == "CentOS" and ansible_distribution_major_version < '7' and "ansible_facts.packages.filebeat[0].version != version"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -26,10 +26,12 @@
   systemd:
     name: filebeat
     enabled: yes
+    state: restarted
   when: ansible_distribution == "CentOS" and ansible_distribution_major_version > '6'
 
 - name: Filebeat service enabled - initid lovers
   service:
     name: filebeat
     enabled: yes
+    state: restarted
   when: ansible_distribution == "CentOS" and ansible_distribution_major_version < '7'

--- a/templates/filebeat.yml.jinja
+++ b/templates/filebeat.yml.jinja
@@ -4,20 +4,7 @@ filebeat.config:
     reload.enabled: false
 
 filebeat.inputs:
-- type: log
-  paths:
-{% for paths in pipelinematch.paths %}
-  {% for item in paths %}
-  - {{ item }}
-  {% endfor %}
-{% endfor %}
-
-  tags:
-{% for tags in pipelinematch.tags %}
-  {% for item in tags %}
-  - {{ item }}
-  {% endfor %}
-{% endfor %}
+{{ processors | to_yaml}}
 
 output.elasticsearch:
   hosts: {{ elastic_hosts | to_yaml }}

--- a/templates/filebeat.yml.jinja
+++ b/templates/filebeat.yml.jinja
@@ -6,10 +6,18 @@ filebeat.config:
 filebeat.inputs:
 - type: log
   paths:
-{% for path in paths %}
-  - {{ path }}
+{% for paths in pipelinematch.paths %}
+  {% for item in paths %}
+  - {{ item }}
+  {% endfor %}
 {% endfor %}
-  tags: {{ log_tags | to_yaml }}
+
+  tags:
+{% for tags in pipelinematch.tags %}
+  {% for item in tags %}
+  - {{ item }}
+  {% endfor %}
+{% endfor %}
 
 output.elasticsearch:
   hosts: {{ elastic_hosts | to_yaml }}


### PR DESCRIPTION
- pipelinematch: list of tags and list of paths to be parsed by filebeat. The cmp default pipeline hast he logic to act upon the combination of tags and paths, to forward the log to the appropiate target pipeline.

- ensure filebeat package is removed ,if present and different version than specified in role call.
- logic to enable filebeat service in both systemd and initd based boxes.